### PR TITLE
Add className prop to allow for deeper customizability and overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "peerDependencies": {
     "@material-ui/core": "^1.0.0",
+    "@material-ui/icons": "^1.0.0",
     "react": "^16.3.0"
   },
   "dependencies": {

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -106,6 +106,7 @@ class SearchBar extends Component {
   render () {
     const { value } = this.state
     const {
+      className,
       classes,
       closeIcon,
       disabled,
@@ -117,7 +118,7 @@ class SearchBar extends Component {
 
     return (
       <Paper
-        className={classes.root}
+        className={classNames(classes.root, className)}
         style={style}
       >
         <div className={classes.searchContainer}>
@@ -167,6 +168,7 @@ class SearchBar extends Component {
 }
 
 SearchBar.defaultProps = {
+  className: '',
   closeIcon: <ClearIcon style={{ color: grey[500] }} />,
   disabled: false,
   placeholder: 'Search',
@@ -176,6 +178,8 @@ SearchBar.defaultProps = {
 }
 
 SearchBar.propTypes = {
+  /** Custom top-level class */
+  className: PropTypes.string,
   /** Override or extend the styles applied to the component. */
   classes: PropTypes.object.isRequired,
   /** Override the close icon. */


### PR DESCRIPTION
The current architecture prevents customizing the styles when using a third party library that passes run-time generated class names via the `className` prop (i.e. `styled-components`). This update will fix that while also staying close to the material-ui component spec which passes this prop to their components as well.