### PR TITLE
Improve TypeScript definitions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Material Search Bar
 // Project: https://github.com/TeamWertarbyte/material-ui-search-bar
-// Definitions by: [Tyler Kellogg] <recurrence@gmail.com>
+// Original definitions by: [Tyler Kellogg] <recurrence@gmail.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="react" />
@@ -27,7 +27,7 @@ declare module 'material-ui-search-bar' {
       /**
        * Custom top-level class.
        */
-      className?: string
+      className?: string;
       /**
        * Override the close icon.
        */
@@ -55,7 +55,7 @@ declare module 'material-ui-search-bar' {
       /**
        * Override the search icon.
        */
-      searchIcon?: JSX.Element
+      searchIcon?: JSX.Element;
       /**
        * Override the inline-styles of the root element.
        */

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,6 +8,18 @@
 declare module 'material-ui-search-bar' {
   export interface SearchBarProps {
       /**
+       * Whether to clear search on escape.
+       */
+      cancelOnEscape?: boolean;
+      /**
+       * Override or extend the styles applied to the component.
+       */
+      classes?: any;
+      /**
+       * Custom top-level class.
+       */
+      className?: string
+      /**
        * Override the close icon.
        */
       closeIcon?: any;
@@ -15,6 +27,10 @@ declare module 'material-ui-search-bar' {
        * Disables text field.
        */
       disabled?: any;
+      /**
+       * Fired when the search is cancelled.
+       */
+      onCancelSearch?(): void;
       /**
        * Sets placeholder for the embedded text field.
        */
@@ -31,10 +47,6 @@ declare module 'material-ui-search-bar' {
        * Override the search icon.
        */
       searchIcon?: any;
-      /**
-       * The element class.
-       */
-      className?: string
       /**
        * Override the inline-styles of the root element.
        */

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -32,6 +32,10 @@ declare module 'material-ui-search-bar' {
        */
       searchIcon?: any;
       /**
+       * The element class.
+       */
+      className?: string
+      /**
        * Override the inline-styles of the root element.
        */
       style?: any;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -14,7 +14,16 @@ declare module 'material-ui-search-bar' {
       /**
        * Override or extend the styles applied to the component.
        */
-      classes?: any;
+      classes?: {
+        root?: string,
+        iconButton?: string,
+        iconButtonHidden?: string,
+        iconButtonDisabled?: string,
+        searchIconButton?: string,
+        icon?: string,
+        input?: string,
+        searchContainer?: string
+      };
       /**
        * Custom top-level class.
        */
@@ -22,19 +31,15 @@ declare module 'material-ui-search-bar' {
       /**
        * Override the close icon.
        */
-      closeIcon?: any;
+      closeIcon?: JSX.Element;
       /**
        * Disables text field.
        */
-      disabled?: any;
+      disabled?: boolean;
       /**
        * Fired when the search is cancelled.
        */
       onCancelSearch?(): void;
-      /**
-       * Sets placeholder for the embedded text field.
-       */
-      placeholder?: any;
       /**
        * Fired when the text value changes.
        */
@@ -44,13 +49,17 @@ declare module 'material-ui-search-bar' {
        */
       onRequestSearch?(): void;
       /**
+       * Sets placeholder for the embedded text field.
+       */
+      placeholder?: string;
+      /**
        * Override the search icon.
        */
-      searchIcon?: any;
+      searchIcon?: JSX.Element
       /**
        * Override the inline-styles of the root element.
        */
-      style?: any;
+      style?: object;
       /**
        * The value of the text field.
        */


### PR DESCRIPTION
When using TypeScript, including className property produces the following warning:

"Property 'className' does not exist on type 'IntrinsicAttributes & SearchBarProps & { children?: ReactNode; }'."