### PR TITLE
Fix onCancelSearch warning

### DIFF
--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -114,6 +114,7 @@ class SearchBar extends Component {
       classes,
       closeIcon,
       disabled,
+      onCancelSearch,
       onRequestSearch,
       searchIcon,
       style,


### PR DESCRIPTION
The `onCancelSearch` prop is getting inadvertently passed to `<Input />` which was causing the javascript warning below.  We need to ensure `onCancelSearch` does not sneak into `...inputProps` before passing them to `<Input />`.

<img width="561" alt="screen shot 2018-08-03 at 8 43 54 pm" src="https://user-images.githubusercontent.com/766787/43671373-560eb95c-975e-11e8-8064-ccb360d6df04.png">
