### PR TITLE
Set defaults for optional props

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ return (
 
 \* required property
 
+Any other properties supplied will be spread to the underlying [`Input`](https://material-ui.com/api/input/#input) component.
+
 ## License
 
 The files included in this repository are licensed under the MIT license.

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -9,6 +9,8 @@ import { grey } from '@material-ui/core/colors'
 import withStyles from '@material-ui/core/styles/withStyles'
 import classNames from 'classnames'
 
+const noop = () => {}
+
 const styles = {
   root: {
     height: 48,
@@ -67,9 +69,7 @@ class SearchBar extends Component {
 
   handleFocus = (e) => {
     this.setState({focus: true})
-    if (this.props.onFocus) {
-      this.props.onFocus(e)
-    }
+    this.props.onFocus(e)
   }
 
   handleBlur = (e) => {
@@ -77,23 +77,18 @@ class SearchBar extends Component {
     if (this.state.value.trim().length === 0) {
       this.setState({value: ''})
     }
-    if (this.props.onBlur) {
-      this.props.onBlur(e)
-    }
+
+    this.props.onBlur(e)
   }
 
   handleInput = (e) => {
     this.setState({value: e.target.value})
-    if (this.props.onChange) {
-      this.props.onChange(e.target.value)
-    }
+    this.props.onChange(e.target.value)
   }
 
   handleCancel = () => {
     this.setState({active: false, value: ''})
-    if (this.props.onCancelSearch) {
-      this.props.onCancelSearch()
-    }
+    this.props.onCancelSearch()
   }
 
   handleKeyUp = (e) => {
@@ -102,9 +97,8 @@ class SearchBar extends Component {
     } else if (this.props.cancelOnEscape && (e.charCode === 27 || e.key === 'Escape')) {
       this.handleCancel()
     }
-    if (this.props.onKeyUp) {
-      this.props.onKeyUp(e)
-    }
+
+    this.props.onKeyUp(e)
   }
 
   render () {
@@ -181,7 +175,12 @@ SearchBar.defaultProps = {
   placeholder: 'Search',
   searchIcon: <SearchIcon style={{ color: grey[500] }} />,
   style: null,
-  value: ''
+  value: '',
+  onBlur: noop,
+  onFocus: noop,
+  onKeyUp: noop,
+  onChange: noop,
+  onCancelSearch: noop
 }
 
 SearchBar.propTypes = {

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -9,8 +9,6 @@ import { grey } from '@material-ui/core/colors'
 import withStyles from '@material-ui/core/styles/withStyles'
 import classNames from 'classnames'
 
-const noop = () => {}
-
 const styles = {
   root: {
     height: 48,
@@ -69,7 +67,9 @@ class SearchBar extends Component {
 
   handleFocus = (e) => {
     this.setState({focus: true})
-    this.props.onFocus(e)
+    if (this.props.onFocus) {
+      this.props.onFocus(e)
+    }
   }
 
   handleBlur = (e) => {
@@ -77,18 +77,23 @@ class SearchBar extends Component {
     if (this.state.value.trim().length === 0) {
       this.setState({value: ''})
     }
-
-    this.props.onBlur(e)
+    if (this.props.onBlur) {
+      this.props.onBlur(e)
+    }
   }
 
   handleInput = (e) => {
     this.setState({value: e.target.value})
-    this.props.onChange(e.target.value)
+    if (this.props.onChange) {
+      this.props.onChange(e.target.value)
+    }
   }
 
   handleCancel = () => {
     this.setState({active: false, value: ''})
-    this.props.onCancelSearch()
+    if (this.props.onCancelSearch) {
+      this.props.onCancelSearch()
+    }
   }
 
   handleKeyUp = (e) => {
@@ -97,8 +102,9 @@ class SearchBar extends Component {
     } else if (this.props.cancelOnEscape && (e.charCode === 27 || e.key === 'Escape')) {
       this.handleCancel()
     }
-
-    this.props.onKeyUp(e)
+    if (this.props.onKeyUp) {
+      this.props.onKeyUp(e)
+    }
   }
 
   render () {
@@ -175,12 +181,7 @@ SearchBar.defaultProps = {
   placeholder: 'Search',
   searchIcon: <SearchIcon style={{ color: grey[500] }} />,
   style: null,
-  value: '',
-  onBlur: noop,
-  onFocus: noop,
-  onKeyUp: noop,
-  onChange: noop,
-  onCancelSearch: noop
+  value: ''
 }
 
 SearchBar.propTypes = {
@@ -198,12 +199,6 @@ SearchBar.propTypes = {
   onCancelSearch: PropTypes.func,
   /** Fired when the text value changes. */
   onChange: PropTypes.func,
-  /** The text field onKeyUp event handler. */
-  onKeyUp: PropTypes.func,
-  /** Fired then the text field loses focus. */
-  onBlur: PropTypes.func,
-  /** Fired then the text field receives focus. */
-  onFocus: PropTypes.func,
   /** Fired when the search icon is clicked. */
   onRequestSearch: PropTypes.func,
   /** Sets placeholder text for the embedded text field. */

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -199,6 +199,12 @@ SearchBar.propTypes = {
   onCancelSearch: PropTypes.func,
   /** Fired when the text value changes. */
   onChange: PropTypes.func,
+  /** The text field onKeyUp event handler. */
+  onKeyUp: PropTypes.func,
+  /** Fired then the text field loses focus. */
+  onBlur: PropTypes.func,
+  /** Fired then the text field receives focus. */
+  onFocus: PropTypes.func,
   /** Fired when the search icon is clicked. */
   onRequestSearch: PropTypes.func,
   /** Sets placeholder text for the embedded text field. */


### PR DESCRIPTION
I added onKeyUp, onBlur and onFocus to the defaultProps static property as this props are used in the component.

Also, I seted defaults for the all optional functions.

My points are: 
This is a good practice in the react, to have default values for all optional props
It helps to write more clear code, as you don't need to do all this if-checks all the time
It helps to avoid bugs in case if someone forgot to make a check. For example, we have a check for `onRequestSearch` [here](https://github.com/TeamWertarbyte/material-ui-search-bar/blob/794e54b970bb9e4bca3dd1e1710fb48f266e79f6/src/components/SearchBar/SearchBar.js#L100), but there is no check [45 lines below](https://github.com/TeamWertarbyte/material-ui-search-bar/blob/794e54b970bb9e4bca3dd1e1710fb48f266e79f6/src/components/SearchBar/SearchBar.js#L145)

Hope this PR will be helpful!
If you like it, should I add new properties to the "SearchBar Properties" section of README?