### PR TITLE
Support for autoFocus attribute in typescript

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -64,6 +64,10 @@ declare module 'material-ui-search-bar' {
        * The value of the text field.
        */
       value?: string;
+      /**
+        * Whether to focus SearchBar on render.
+        */
+      autoFocus?: boolean;
   }
 
   const SearchBar: React.ComponentType<SearchBarProps>;


### PR DESCRIPTION
Based on issue #95
Fixes typescript support for the autoFocus attribute